### PR TITLE
Fix maven-eclipse-plugin in pom.xml

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -234,11 +234,11 @@
 				<artifactId>maven-eclipse-plugin</artifactId>
 				<version>2.9</version>
 				<configuration>
-                    <sourceIncludes>
-                        <sourceInclude>**/*</sourceInclude>
-                    </sourceIncludes>
-                    <downloadSources>true</downloadSources>
-                    <downloadJavadocs>true</downloadJavadocs>
+					<sourceIncludes>
+						<sourceInclude>**/*</sourceInclude>
+					</sourceIncludes>
+					<downloadSources>true</downloadSources>
+					<downloadJavadocs>true</downloadJavadocs>
 					<additionalProjectnatures>
 						<projectnature>org.eclipse.m2e.core.maven2Nature</projectnature>
 						<projectnature>com.google.appengine.eclipse.core.gaeNature</projectnature>


### PR DESCRIPTION
There is an extra 'configuration' tag which causes the pom to be invalid.
